### PR TITLE
Company name does not appear in Google 2FA

### DIFF
--- a/modules/addons/oath/oath.php
+++ b/modules/addons/oath/oath.php
@@ -91,7 +91,7 @@ function oath_clientarea($vars) {
         }
 
         global $CONFIG;
-        $company2 = $CONFIG['CompanyName'];
+        $company = $CONFIG['CompanyName'];
         QRcode::png('otpauth://totp/' . $user . '?issuer=' . urlencode($company) . '&secret=' . $_GET['secret']);
         exit(0);
     }
@@ -267,7 +267,7 @@ function oath_output($vars) {
         }
 
         global $CONFIG;
-        $company2 = $CONFIG['CompanyName'];
+        $company = $CONFIG['CompanyName'];
         QRcode::png('otpauth://totp/' . $user . '?issuer=' . urlencode($company) . '&secret=' . $_GET['secret']);
         exit(0);
     }


### PR DESCRIPTION
Company name does not appear in Google 2FA because of variable $company2 is wrong. It should be $company only (WHMCS use $company, Not $company2)

Please check, If look ok for you then accept my humble request. It will help many users who is using it.